### PR TITLE
"Wrong listener selected !" change to "Wrong session selected !"

### DIFF
--- a/octopus.py
+++ b/octopus.py
@@ -60,7 +60,7 @@ while True:
                 session = connections_information[int(command.split(" ")[1])]
                 delete(session[2], int(command.split(" ")[1]))
             except:
-                print(colored("[-] Wrong listener selected !", "red"))
+                print(colored("[-] Wrong session selected !", "red"))
                 continue
 
 


### PR DESCRIPTION
"Wrong session selected !" message for session deletion instead of "Wrong listener selected !" for both sessions and listeners. Closes #15  