### PR TITLE
Update delete_listener with ability to delete HTTPS listeners

### DIFF
--- a/core/weblistener.py
+++ b/core/weblistener.py
@@ -16,6 +16,8 @@ from .encryption import *
 from .esa import *
 from flask import *
 import logging
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 parentfolder = os.path.abspath("..")
 if parentfolder not in sys.path:
     sys.path.insert(0, parentfolder)
@@ -199,12 +201,16 @@ def delete_listener(listener_name):
         listener_info = listeners_information.get(listener_name)
         host = listener_info[1]
         port = listener_info[2]
+        is_ssl = listener_info[6]
     except:
         print(colored("[-] Worng listener name!", "red"))
         return False
 
     data = {"shutdown_token": kill_listener_token}
-    request = web_requests.post("http://%s:%s/%s" % (host, port, kill_listener_url), data=data)
+    if is_ssl == True:
+        request = web_requests.post("https://%s:%s/%s" % (host, port, kill_listener_url), data=data, verify=False)
+    else:
+        request = web_requests.post("http://%s:%s/%s" % (host, port, kill_listener_url), data=data)
     if request.text == "d":
         del listeners_information[listener_name]
         print(colored("[+] Listener %s has been deleted" % (listener_name), "green"))


### PR DESCRIPTION
In /core/weblistener.py, the function delete_listener was only able to delete http listeners but not https. Closes #17 

This was due to there only being an http url for the web_request POST request...

![http](https://user-images.githubusercontent.com/43627224/93428301-09a62680-f874-11ea-9595-3b7906030c10.png)

and when an https url was added, python errored out with SSL warnings.

![warn](https://user-images.githubusercontent.com/43627224/93428307-0f037100-f874-11ea-8a0a-1f1acdcfbd2f.png)

Added lines 19 and 20 to allow SSL warnings to be ignored (self signed etc.), this was from https://stackoverflow.com/questions/27981545/suppress-insecurerequestwarning-unverified-https-request-is-being-made-in-pytho/33716188
![pythonSSLwarn](https://user-images.githubusercontent.com/43627224/93427080-10cc3500-f872-11ea-9e12-cee30de62c64.PNG)

Added line 204 `is_ssl` variable to check if the listener has SSL or not.
For lines 210 - 213, used existing python requests, added an if statement to check for `is_ssl` and `verify=False` for SSL certs.

![delete](https://user-images.githubusercontent.com/43627224/93427640-02cae400-f873-11ea-8a07-168eafccb951.png)
