### PR TITLE
Add "Sophos" string for EDR detection

### DIFF
--- a/core/esa.py
+++ b/core/esa.py
@@ -19,7 +19,7 @@ AV_list = {
     "F-Secure": ["fsdevcon", "FSORSPClient"],
     "MacAfee": ["enterceptagent", "McAfeeEngineService", "McAfeeFramework", "McCSPServiceHost", "MfeAVSvc"],
     "SentinelOne": ["SentinelAgent", "SentinelOne"],
-    "Sophos": ["sophosssp", "sophossps"],
+    "Sophos": ["sophosssp", "sophossps", "Sophos"],
     "TrendMicro": ["tmntsrv"],
     "Windows Defender": ["MsMpEng"],
     "ZoneALarm": ["zlclient"],


### PR DESCRIPTION
After adding the string, report detects active Sophos EDR...

![image](https://user-images.githubusercontent.com/43627224/119915973-77811280-bf18-11eb-979f-dac931616ee4.png)

Fixes #26 